### PR TITLE
Fix the ability to use non-metric units

### DIFF
--- a/AircraftLabel.h
+++ b/AircraftLabel.h
@@ -33,7 +33,7 @@ class AircraftLabel {
 
 		float labelLevel;
 
-		bool metric;
+		bool metric {};
 
 		float x;
 		float y;

--- a/View.h
+++ b/View.h
@@ -128,7 +128,7 @@ class View {
 
 
 	////////////////
-		bool metric;
+		bool metric {};
 
 		bool fps;
 

--- a/viz1090.cpp
+++ b/viz1090.cpp
@@ -115,6 +115,7 @@ int main(int argc, char **argv) {
             exit(1);
         }
     }
+    fprintf(stderr, "view.metric is '%d'.\n\n", view.metric);
     
     int go;
   


### PR DESCRIPTION
I noticed that viz1090 always displays aircraft data and the legend in metric units, regardless of whether or not I passed `--metric`.

I added a debugging statement and found that the `metric` boolean was uninitialized when not set to `TRUE` by passing `--metric`. This is in the first commit and is just to demonstrate the problem.

I'm not a C++ programmer but the second commit does fix the issue for me. Sorry if this solution is not idiomatic.