### PR TITLE
Download links in the `getmap` script and cleanup the map data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,11 @@ viz1090: viz1090.o AppData.o AircraftList.o Aircraft.o Label.o AircraftLabel.o a
 	$(CXX) -o viz1090 viz1090.o AppData.o AircraftList.o Aircraft.o Label.o AircraftLabel.o anet.o interactive.o mode_ac.o mode_s.o net_io.o Input.o View.o Map.o parula.o monokai.o $(LIBS) $(LDFLAGS)
 
 clean:
-	rm -f *.o viz1090
+	rm -f \
+		airportdata.bin \
+		airportnames \
+		mapdata/* \
+		mapdata.bin \
+		mapnames \
+		*.o \
+		viz1090

--- a/getmap.sh
+++ b/getmap.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 
-wget https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_admin_1_states_provinces.zip
-wget https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_populated_places.zip
-wget https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/10m/cultural/ne_10m_airports.zip
+mkdir -p mapdata
+pushd mapdata > /dev/null
+
+wget --no-verbose https://naciscdn.org/naturalearth/10m/cultural/ne_10m_admin_1_states_provinces.zip
+wget --no-verbose https://naciscdn.org/naturalearth/10m/cultural/ne_10m_populated_places.zip
+wget --no-verbose https://naciscdn.org/naturalearth/10m/cultural/ne_10m_airports.zip
 
 #this may not be up to date
-wget https://opendata.arcgis.com/datasets/4d8fa46181aa470d809776c57a8ab1f6_0.zip  
+wget --no-verbose https://opendata.arcgis.com/datasets/4d8fa46181aa470d809776c57a8ab1f6_0.zip
 
-unzip '*.zip'
+for file in *.zip; do
+    unzip -o "${file}"
+    rm "${file}"
+done
 
-python3 mapconverter.py --mapfile ne_10m_admin_1_states_provinces.shp --mapnames ne_10m_populated_places.shp --airportfile Runways.shp --airportnames ne_10m_airports.shp 
+popd > /dev/null
+
+python3 mapconverter.py \
+	--mapfile mapdata/ne_10m_admin_1_states_provinces.shp \
+	--mapnames mapdata/ne_10m_populated_places.shp \
+	--airportfile mapdata/Runways.shp \
+	--airportnames mapdata/ne_10m_airports.shp 


### PR DESCRIPTION
This pull request resolves #12.

Aside from the changes to the download links, I let the `getmap.sh` script download and extract all the files inside a new directory `mapdata` and added all the downloaded and generated files to the `make clean` command.