### PR TITLE
Fix shaky FPS box

### DIFF
--- a/src/app/viz1090.cpp
+++ b/src/app/viz1090.cpp
@@ -90,7 +90,7 @@ main(int argc, char** argv) {
     } else if (!std::strcmp(argv[j], "--metric")) {
       view.metric = 1;
     } else if (!std::strcmp(argv[j], "--fps")) {
-      view.fps = 1;
+      view.getUIOverlay()->setShowFps(1);
     } else if (!std::strcmp(argv[j], "--fullscreen")) {
       view.fullscreen = 1;
     } else if (!std::strcmp(argv[j], "--flip-touch")) {

--- a/src/ui/Input.cpp
+++ b/src/ui/Input.cpp
@@ -90,6 +90,11 @@ Input::getInput() {
             view->getMapView().setMoved();
             break;
 
+          // toggle FPS box
+          case SDLK_f:
+            view->getUIOverlay()->setShowFps(!view->getUIOverlay()->getShowFps());
+            break;
+
           default:
             break;
         }

--- a/src/ui/UIOverlay.cpp
+++ b/src/ui/UIOverlay.cpp
@@ -150,7 +150,7 @@ void UIOverlay::draw(const RenderContext& ctx, const AppData& appData, float las
 
   if (showFps) {
     char fps[60] = " ";
-    snprintf(fps, 40, "%.1f", 1000.0f / lastFrameTime);
+    snprintf(fps, 40, "%5.1f", 1000.0f / lastFrameTime);
 
     drawStatusBox(ctx, &left, &top, "fps", fps, ctx.style->grey_dark);
   }
@@ -159,7 +159,7 @@ void UIOverlay::draw(const RenderContext& ctx, const AppData& appData, float las
     drawStatusBox(ctx, &left, &top, "init", "connecting", ctx.style->red);
   } else {
     char strLoc[20] = " ";
-    snprintf(strLoc, 20, "%3.3fN %3.3f%c", centerLat, std::fabs(centerLon),
+    snprintf(strLoc, 20, "%7.3fN %7.3f%c", centerLat, std::fabs(centerLon),
              (centerLon > 0) ? 'E' : 'W');
     drawStatusBox(ctx, &left, &top, "loc", strLoc, ctx.style->buttonColor);
 

--- a/src/ui/View.cpp
+++ b/src/ui/View.cpp
@@ -332,7 +332,6 @@ View::draw() {
   }
 
   // Draw status overlay (status bar and menu button)
-  uiOverlay.setShowFps(fps);
   uiOverlay.draw(renderContext, *appData, lastFrameTime, mapView.centerLat, mapView.centerLon,
                  mapView.map.loaded);
 

--- a/src/ui/View.h
+++ b/src/ui/View.h
@@ -80,7 +80,6 @@ public:
 
   // Configuration
   bool metric{false};
-  bool fps{false};
 
   // Screen configuration
   int screen_upscale{1};
@@ -98,6 +97,8 @@ public:
   // Expose map view for external access to viewport state
   MapView& getMapView() { return mapView; }
   const MapView& getMapView() const { return mapView; }
+
+  UIOverlay* getUIOverlay() { return &uiOverlay; }
 
 private:
   TTF_Font* loadFont(const char* name, int size);


### PR DESCRIPTION
When FPS changes number of digits the box adjusts width. With values close to 9/10 or 99/100, the buttons row moves back and forth (It is also for LON/LAT boxes). Also, I added a input key 'f' which toggles the FPS box, so it can be changed after program start.