### PR TITLE
Fixes imperial/metric conversion

### DIFF
--- a/src/ui/AircraftLabel.cpp
+++ b/src/ui/AircraftLabel.cpp
@@ -64,18 +64,18 @@ AircraftLabel::update() {
 
   char alt[10] = "";
   if (metric) {
-    snprintf(alt, 10, " %dm", static_cast<int>(p->altitude / 3.2828));
+    snprintf(alt, 10, "%d m", static_cast<int>(p->altitude / 3.2828));
   } else {
-    snprintf(alt, 10, " %d'", p->altitude);
+    snprintf(alt, 10, "%d'", p->altitude);
   }
 
   altitudeLabel.setText(alt);
 
   char speed[10] = "";
   if (metric) {
-    snprintf(speed, 10, " %dkm/h", static_cast<int>(p->speed * 1.852));
+    snprintf(speed, 10, "%d km/h", static_cast<int>(p->speed * 1.852));
   } else {
-    snprintf(speed, 10, " %dmph", p->speed);
+    snprintf(speed, 10, "%d mph", p->speed);
   }
 
   speedLabel.setText(speed);
@@ -603,7 +603,7 @@ AircraftLabel::getIsChanging() {
   return isChanging;
 }
 
-AircraftLabel::AircraftLabel(Aircraft* p, bool metric, int screen_width, int screen_height,
+AircraftLabel::AircraftLabel(Aircraft* p, bool& metric, int screen_width, int screen_height,
                              TTF_Font* font, const Style& style)
     : p(p),
       labelLevel(0),

--- a/src/ui/AircraftLabel.h
+++ b/src/ui/AircraftLabel.h
@@ -22,7 +22,7 @@ public:
 
   void draw(SDL_Renderer* renderer, bool selected);
 
-  AircraftLabel(Aircraft* p, bool metric, int screen_width, int screen_height, TTF_Font* font,
+  AircraftLabel(Aircraft* p, bool& metric, int screen_width, int screen_height, TTF_Font* font,
                 const Style& style);
 
 private:
@@ -38,7 +38,7 @@ private:
 
   float labelLevel;
 
-  bool metric;
+  bool& metric;
 
   float x;
   float y;

--- a/src/ui/AircraftRenderer.cpp
+++ b/src/ui/AircraftRenderer.cpp
@@ -463,7 +463,7 @@ void AircraftRenderer::drawOnMapClusters(const RenderContext& ctx, Aircraft* sel
 void AircraftRenderer::drawPlaneText(const RenderContext& ctx, Aircraft* p,
                                      Aircraft* selectedAircraft) {
   if (!p->label) {
-    p->label = std::make_unique<AircraftLabel>(p, metric, ctx.screenWidth, ctx.screenHeight,
+    p->label = std::make_unique<AircraftLabel>(p, *metric, ctx.screenWidth, ctx.screenHeight,
                                                ctx.mapFont, *ctx.style);
   }
 

--- a/src/ui/AircraftRenderer.h
+++ b/src/ui/AircraftRenderer.h
@@ -84,8 +84,7 @@ public:
   void moveLabels(AircraftList& aircraftList, float dx, float dy);
 
   // Configuration
-  void setMetric(bool metric) { this->metric = metric; }
-  [[nodiscard]] bool getMetric() const { return metric; }
+  void setMetric(bool* metric) { this->metric = metric; }
 
   // Check if any animation needs high framerate
   [[nodiscard]] bool needsHighFramerate() const { return highFramerate; }
@@ -110,7 +109,7 @@ private:
                          SDL_Color planeColor, Aircraft* aircraft);
   void drawOnMapClusters(const RenderContext& ctx, Aircraft* selectedAircraft);
 
-  bool metric{false};
+  bool* metric{nullptr};
   bool highFramerate{false};
 
   // Off-map plane clusters - greedy distance-based

--- a/src/ui/Input.cpp
+++ b/src/ui/Input.cpp
@@ -90,6 +90,11 @@ Input::getInput() {
             view->getMapView().setMoved();
             break;
 
+          // toggle metric/imperial units
+          case SDLK_m:
+            view->metric = !view->metric;
+            break;
+
           default:
             break;
         }

--- a/src/ui/MapView.cpp
+++ b/src/ui/MapView.cpp
@@ -37,7 +37,7 @@
 
 namespace viz1090 {
 
-MapView::MapView() {
+MapView::MapView(bool& metric) : metric{metric} {
   lastRedraw = now();
 }
 
@@ -456,26 +456,30 @@ void MapView::drawScaleBars(const RenderContext& ctx) {
   int scaleBarDist = screenDist(static_cast<float>(std::pow(10, scalePower)),
                                 ctx.screenWidth, ctx.screenHeight);
 
+  const float baseUnit = metric ? 1.0 : 1.852; // 1 Mn = 1852 m;
+
   char scaleLabel[13] = "";
 
-  lineRGBA(ctx.renderer, 10, 10, 10, 10 * ctx.uiScale, ctx.style->scaleBarColor.r,
-           ctx.style->scaleBarColor.g, ctx.style->scaleBarColor.b, 255);
+  // not sure what is this supposed to draw?
+  // lineRGBA(ctx.renderer, 10, 10, 10, 10 * ctx.uiScale, ctx.style->scaleBarColor.r,
+  //          ctx.style->scaleBarColor.g, ctx.style->scaleBarColor.b, 255);
 
-  while (scaleBarDist < ctx.screenWidth) {
-    lineRGBA(ctx.renderer, 10 + scaleBarDist, 8, 10 + scaleBarDist, 16 * ctx.uiScale,
+  while (baseUnit * scaleBarDist < ctx.screenWidth) {
+
+    lineRGBA(ctx.renderer, baseUnit * (10 + scaleBarDist), 8, baseUnit * (10 + scaleBarDist), 16 * ctx.uiScale,
              ctx.style->scaleBarColor.r, ctx.style->scaleBarColor.g,
              ctx.style->scaleBarColor.b, 255);
 
     if (metric) {
-      snprintf(scaleLabel, 13, "%dkm", static_cast<int>(std::pow(10, scalePower)));
+      snprintf(scaleLabel, 13, "%d km", static_cast<int>(std::pow(10, scalePower)));
     } else {
-      snprintf(scaleLabel, 13, "%dmi", static_cast<int>(std::pow(10, scalePower)));
+      snprintf(scaleLabel, 13, "%d Mm", static_cast<int>(std::pow(10, scalePower)));
     }
 
     Label currentLabel;
     currentLabel.setFont(ctx.mapFont);
     currentLabel.setColor(ctx.style->scaleBarColor);
-    currentLabel.setPosition(10 + scaleBarDist, 15 * ctx.uiScale);
+    currentLabel.setPosition(baseUnit * (10 + scaleBarDist), 15 * ctx.uiScale);
     currentLabel.setText(scaleLabel);
     currentLabel.draw(ctx.renderer);
 
@@ -488,7 +492,7 @@ void MapView::drawScaleBars(const RenderContext& ctx) {
   scaleBarDist = screenDist(static_cast<float>(std::pow(10, scalePower)),
                             ctx.screenWidth, ctx.screenHeight);
 
-  lineRGBA(ctx.renderer, 10, 10 + 5 * ctx.uiScale, 10 + scaleBarDist, 10 + 5 * ctx.uiScale,
+  lineRGBA(ctx.renderer, 0, 10 + 5 * ctx.uiScale, baseUnit * (10 + scaleBarDist), 10 + 5 * ctx.uiScale,
            ctx.style->scaleBarColor.r, ctx.style->scaleBarColor.g,
            ctx.style->scaleBarColor.b, 255);
 }

--- a/src/ui/MapView.h
+++ b/src/ui/MapView.h
@@ -43,7 +43,7 @@ constexpr float LATLONMULT = 111.195f;  // 6371.0 * M_PI / 180.0
 /// Handles map viewport, coordinate transformations, and geography rendering
 class MapView {
 public:
-  MapView();
+  MapView(bool& metric);
 
   /// Initialize the map texture for caching
   void initTexture(SDL_Renderer* renderer, int width, int height);
@@ -87,7 +87,7 @@ public:
   float mapTargetLat{0.0f};
   float mapTargetMaxDist{0.0f};
 
-  bool metric{false};
+  bool& metric;
 
   // Map data
   Map map;

--- a/src/ui/View.cpp
+++ b/src/ui/View.cpp
@@ -364,15 +364,14 @@ View::draw() {
 //
 
 View::View(AppData* appData)
-    : appData(appData) {
+    : appData(appData), mapView(metric) {
   // Load themes from the themes directory
   if (!styleManager_.loadFromDirectory("themes")) {
     std::fprintf(stderr, "Warning: No themes loaded from 'themes' directory\n");
   }
 
   // Set metric preference on components
-  mapView.metric = metric;
-  aircraftRenderer.setMetric(metric);
+  aircraftRenderer.setMetric(&metric);
 
   // Set up UI callbacks
   uiOverlay.setFrameAllCallback([this]() { frameAllAircraft(); });


### PR DESCRIPTION
1. When drawing scale bar, 1 mile unit was draw the same like 1 km, now 1 Mm = 1.852 km
2. Physical units are now printed with space between value and unit (as is correct), also removed some leading spaces
3. Key 'm' toggles between metric/imperial units